### PR TITLE
feat: Add built image url to acr-task outputs

### DIFF
--- a/acr-task/action.yml
+++ b/acr-task/action.yml
@@ -41,6 +41,10 @@ inputs:
     description: 'The location of the Dockerfile; defaults to ./Dockerfile'
     required: false
 
+outputs:
+  image_url:
+    description: 'Full tagged URL for image that was generated'
+
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/acr-task/entrypoint.sh
+++ b/acr-task/entrypoint.sh
@@ -22,3 +22,6 @@ else
   echo "Executing agaisnt public repository"
   az acr build -r ${INPUT_REGISTRY} -f ${INPUT_DOCKERFILE} -t ${INPUT_REPOSITORY}${IMAGE_PART}:${INPUT_TAG} https://github.com/${GITHUB_REPOSITORY}.git#${INPUT_BRANCH}:${INPUT_FOLDER}
 fi
+
+IMAGE_URL=${INPUT_REGISTRY}.azurecr.io/${INPUT_REPOSITORY}${IMAGE_PART}:${INPUT_TAG}
+echo "::set-output name=image_url::$IMAGE_URL"


### PR DESCRIPTION
Quality of life improvement adding an output `image_url` to the task.  Lets later 
steps consume the image name in full context so they don't need to know the
logic themselves.

For example:
```
jobs:
  build_images:
    runs-on: ubuntu-latest
    outputs:
      training_image_url: ${{ steps.build_training_image.outputs.image_url }}
    steps:
      - name: Build Training Image
        id: build_training_image
        uses: ca-scribner/actions/acr-task@master
      - name: Do something with image name
        run: |
          echo "Above step generated image: ${{ steps.build_scoring_image.outputs.image_url }}" 
  deploy_job:
    needs: [build_images]
    ...
    steps:
      - name: Use image name
        run: echo "Above job generated image: ${{ needs.build_images.outputs.training_image_url }}
```